### PR TITLE
Parse string into WherePredicate to improve errors

### DIFF
--- a/macros/src/attr/enum.rs
+++ b/macros/src/attr/enum.rs
@@ -1,11 +1,13 @@
 use std::collections::HashMap;
 
-use syn::{Attribute, Ident, Result, Type};
+use syn::{Attribute, Ident, Result, Type, WherePredicate};
 
 use crate::{
     attr::{parse_assign_inflection, parse_assign_str, parse_concrete, Inflection},
     utils::{parse_attrs, parse_docs},
 };
+
+use super::parse_bound;
 
 #[derive(Default)]
 pub struct EnumAttr {
@@ -16,7 +18,7 @@ pub struct EnumAttr {
     pub export: bool,
     pub docs: String,
     pub concrete: HashMap<Ident, Type>,
-    pub bound: Option<String>,
+    pub bound: Option<Vec<WherePredicate>>,
     tag: Option<String>,
     untagged: bool,
     content: Option<String>,
@@ -85,7 +87,10 @@ impl EnumAttr {
         self.export_to = self.export_to.take().or(export_to);
         self.docs = docs;
         self.concrete.extend(concrete);
-        self.bound = self.bound.take().or(bound);
+        self.bound = self.bound
+            .take()
+            .map(|b| b.into_iter().chain(bound.clone().unwrap_or_default()).collect())
+            .or(bound);
     }
 }
 
@@ -100,7 +105,7 @@ impl_parse! {
         "content" => out.content = Some(parse_assign_str(input)?),
         "untagged" => out.untagged = true,
         "concrete" => out.concrete = parse_concrete(input)?,
-        "bound" => out.bound = Some(parse_assign_str(input)?),
+        "bound" => out.bound = Some(parse_bound(input)?),
     }
 }
 
@@ -112,6 +117,7 @@ impl_parse! {
         "rename_all_fields" => out.0.rename_all_fields = Some(parse_assign_inflection(input)?),
         "tag" => out.0.tag = Some(parse_assign_str(input)?),
         "content" => out.0.content = Some(parse_assign_str(input)?),
-        "untagged" => out.0.untagged = true
+        "untagged" => out.0.untagged = true,
+        "bound" => out.0.bound = Some(parse_bound(input)?),
     }
 }

--- a/macros/src/attr/mod.rs
+++ b/macros/src/attr/mod.rs
@@ -4,7 +4,7 @@ pub use field::*;
 pub use r#enum::*;
 pub use r#struct::*;
 use syn::{
-    parse::{Parse, ParseStream, Parser},
+    parse::{Parse, ParseStream},
     Error, Lit, Result, Token, WherePredicate, punctuated::Punctuated,
 };
 pub use variant::*;
@@ -135,12 +135,7 @@ fn parse_bound(input: ParseStream) -> Result<Vec<WherePredicate>> {
         Lit::Str(string) => {
             let parser = Punctuated::<WherePredicate, Token![,]>::parse_terminated;
 
-            Ok(
-                parser.parse_str(&string.value())
-                    .map_err(|e| Error::new(string.span(), e.to_string()))?
-                    .into_iter()
-                    .collect()
-            )
+            Ok(string.parse_with(parser)?.into_iter().collect())
         },
         other => Err(Error::new(other.span(), "expected string")),
     }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -8,7 +8,7 @@ use quote::{format_ident, quote};
 use syn::{
     parse_quote, spanned::Spanned, ConstParam, GenericParam, Generics, Item, LifetimeParam, Result,
     Type, TypeArray, TypeParam, TypeParen, TypePath, TypeReference, TypeSlice, TypeTuple,
-    WhereClause,
+    WhereClause, WherePredicate,
 };
 
 use crate::{deps::Dependencies, utils::format_generics};
@@ -26,7 +26,7 @@ struct DerivedTS {
     inline_flattened: Option<TokenStream>,
     dependencies: Dependencies,
     concrete: HashMap<Ident, Type>,
-    bound: Option<String>,
+    bound: Option<Vec<WherePredicate>>,
 
     export: bool,
     export_to: Option<String>,
@@ -301,7 +301,7 @@ fn generate_assoc_type(
 fn generate_impl_block_header(
     ty: &Ident,
     generics: &Generics,
-    bounds: Option<&str>,
+    bounds: Option<&[WherePredicate]>,
     dependencies: &Dependencies,
 ) -> TokenStream {
     use GenericParam as G;
@@ -338,8 +338,11 @@ fn generate_impl_block_header(
             quote! { #bounds }
         },
         |bounds| {
-            let bounds = syn::parse_str::<TokenStream>(bounds).expect("malformed `bounds`");
-            quote! { where #bounds }
+            if !bounds.is_empty() {
+                quote! { where #(#bounds),* }
+            } else {
+                quote!()
+            }
         },
     );
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -338,11 +338,7 @@ fn generate_impl_block_header(
             quote! { #bounds }
         },
         |bounds| {
-            if !bounds.is_empty() {
-                quote! { where #(#bounds),* }
-            } else {
-                quote!()
-            }
+            quote! { where #(#bounds),* }
         },
     );
 


### PR DESCRIPTION
## Goal
Improve the locations of errors when receiving invalid syntax

## Changes
Parse the contents of `#[ts(bound = "...")]` into a `syn::punctuated::Punctuated<syn::WherePredicate, syn::Token![,]>`

### Before:
![image](https://github.com/Aleph-Alpha/ts-rs/assets/131818645/8c4d0c6d-6b7e-4aba-9174-b8e784d0cc2e)

### After:
![image](https://github.com/Aleph-Alpha/ts-rs/assets/131818645/3c7b476c-9642-431c-884a-43d367b61629)
